### PR TITLE
fix: respect email_verified in password migration, redact PII from logs

### DIFF
--- a/src/migration_utils.py
+++ b/src/migration_utils.py
@@ -549,7 +549,7 @@ def create_descope_user(user):
                 return True, user.get("name"), True, user.get("user_id")
             return True, user.get("name"), False, ""
     except AuthException as error:
-        logging.error(f"Unable to create user. {user}")
+        logging.error(f"Unable to create user {user.get('user_id', 'unknown')}. Error: {error.error_message}")
         logging.error(f"Error: {error.error_message}")
         return (
             False,
@@ -907,7 +907,7 @@ def build_user_object_with_passwords(extracted_user):
         UserObj(
             login_id=extracted_user['email'],
             email=extracted_user['email'],
-            verified_email=True,#extracted_user['email_verified'],
+            verified_email=extracted_user.get('email_verified', False),
             password=userPasswordToCreate,
             custom_attributes = {
                 "connection": "Username-Password-Authentication",

--- a/src/migration_utils.py
+++ b/src/migration_utils.py
@@ -550,7 +550,6 @@ def create_descope_user(user):
             return True, user.get("name"), False, ""
     except AuthException as error:
         logging.error(f"Unable to create user {user.get('user_id', 'unknown')}. Error: {error.error_message}")
-        logging.error(f"Error: {error.error_message}")
         return (
             False,
             "",


### PR DESCRIPTION
## Summary

- **`build_user_object_with_passwords()`** hard-coded `verified_email=True`, ignoring Auth0's `email_verified` field. Users who never verified their email in Auth0 were imported as verified into Descope. Now uses `extracted_user.get('email_verified', False)`.
- **`create_descope_user()`** error handler logged the full Auth0 user object (email, phone, name, etc.) to disk. Now logs only `user_id` and the error message.

## Credit

Reported by MRKNIGHTNIDU @mrknight-n1du  — CWE-345 / CWE-287 (verified_email) and CWE-532 (PII logging).